### PR TITLE
Fiber types

### DIFF
--- a/Zend/tests/fibers/get-return-after-bailout.phpt
+++ b/Zend/tests/fibers/get-return-after-bailout.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Fiber::getReturn() after bailout
+--FILE--
+<?php
+
+register_shutdown_function(static function (): void {
+    global $fiber;
+    var_dump($fiber->getReturn());
+});
+
+$fiber = new Fiber(static function (): void {
+    str_repeat('X', PHP_INT_MAX);
+});
+$fiber->start();
+
+?>
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted%s(tried to allocate %d bytes) %sget-return-after-bailout.php on line %d
+
+Fatal error: Uncaught FiberError: Cannot get fiber return value: The fiber exited with a fatal error in %sget-return-after-bailout.php:%d
+Stack trace:
+#0 %sget-return-after-bailout.php(%d): Fiber->getReturn()
+#1 [internal function]: {closure}()
+#2 {main}
+  thrown in %sget-return-after-bailout.php on line %d

--- a/Zend/zend_fibers.c
+++ b/Zend/zend_fibers.c
@@ -673,6 +673,8 @@ ZEND_METHOD(Fiber, getReturn)
 	if (fiber->status == ZEND_FIBER_STATUS_DEAD) {
 		if (fiber->flags & ZEND_FIBER_FLAG_THREW) {
 			message = "The fiber threw an exception";
+		} else if (fiber->flags & ZEND_FIBER_FLAG_BAILOUT) {
+			message = "The fiber exited with a fatal error";
 		} else {
 			RETURN_COPY(&fiber->value);
 		}


### PR DESCRIPTION
Adds a "kind" field to `zend_fiber_context` to make sure that different fiber implementations do not get mixed up. The new field is set to `zend_ce_fiber` for PHP fibers and checked in `Fiber::suspend()` and `Fiber::this()` to ensure that these methods can only be called from within a running fiber.

@trowski The main reason for allowing different fiber implementations is to be prepared for async support that might come to PHP in a future version (or be provided by PHP extensions starting with PHP 8.1). Consider an example like this:

```php
$task = async $client->sendRequest($request);
$response = await $task;
```

In this case the `async` expression should evaluate into a PHP object that is backed by a fiber but does not expose the same API as `Fiber` to userland. It would be possible to use the existing `ZEND_API` to create a `Fiber` and store that as a property of the new object, but that would be wasting memory for additional objects. While this is feasible in a userland implementation it would not be reasonable to implement this in C. Having `Fiber` in PHP core is great and it should not be changed / restricted to async-only as there are other use cases for fiber (for example emitting values from deep within a callstack without turning everything into generators).

The great thing about this is that one can easily develop an async implementation as a PHP extension (of course without keyword support) and everybody has a chance to try and evaluate it before going for an RFC. It is also possible for Swoole to use the same approach and reuse some of the code that PHP 8.1 provides for their implementation.

If you agree with this PR I will re-open it in php-src. 

BTW: I also changed the fiber address output in zend_test to be identical to your initial version to make it easier to spot "main".